### PR TITLE
Add method that returns tuple of cartesian coordinates

### DIFF
--- a/vec/__init__.py
+++ b/vec/__init__.py
@@ -627,6 +627,9 @@ class Vector2(metaclass=Vector2Metaclass):
 
     def polar(self):
         return (self.r, self.theta)
+    
+    def cartesian(self):
+        return (self.x, self.y)
 
     def lerp(self, other, ratio):
         assert self._validate()


### PR DESCRIPTION
Add the `cartesian` method that explicitly returns a 2-tuple containing the cartesian coordinates (x and y), with the same behavior as the `polar` method.

EDIT: the main reason I proposed this change was because I thought it would be good to have a quick way of passing the cartesian coordinates around, using `*vector.cartesian()`, but I noticed that using `*vector` has the exact same behavior, so maybe just a mention for this fact in the README would be enough.

EDIT2: thanks for the library, it's well written!